### PR TITLE
fix：打开#settings页面时后端在没有订阅链接的情况下返回 null，导致页面异常

### DIFF
--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -76,7 +76,8 @@ export default function SettingsPanel() {
           fetchSettings(),
           refreshSubStatus(),
         ])
-        const merged = { ...defaultSettings, ...settingsData }
+        const subscriptions = settingsData.subscriptions || []
+        const merged = { ...defaultSettings, ...settingsData, subscriptions }
         setSettings(merged)
         setSavedSettings(merged)
         setIsDirty(false)


### PR DESCRIPTION
在打开/#settings页面时控制台“Uncaught TypeError: Cannot read properties of null (reading 'length')”报错

> 经过仔细分析 SettingsPanel.tsx 文件，我发现了一个潜在的问题。
> 
> 在组件加载时，它会从后端 API 获取设置数据。如果后端在没有订阅链接的情况下返回 null 而不是一个空数组 [] 作为 subscriptions 字段的值，那么在前端代码中任何试图访问 subscriptions.length 的地方都会导致您看到的 Cannot read properties of null (reading 'length') 错误。
> 
> 为了修复这个问题，我将在前端代码中添加一个保障措施，确保 subscriptions 始终是一个数组。这样，即使 API 返回 null ，页面也能正常渲染。

本地构建win64以及deban12上本机构建镜像运行启动通过